### PR TITLE
Update CHaP and hackage

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,7 +16,7 @@ If you _really_ cannot use Nix and still want to contribute, then xref:develop-w
 
 This repository uses Nix to provide the development and build environment.
 
-For instructions on how to install and configure Nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
+For instructions on how to install and configure Nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document].
 
 If you already have Nix installed and configured, you may enter the development shell by running `nix develop`.
 
@@ -114,8 +114,8 @@ Note that `cabal` itself keeps track of what index states it knows about, so whe
 The Nix code which builds our packages also cares about the index state.
 This is represented by some pinned inputs in our flake (see xref:update-nix-pins[here] for more details)
 You can update these by running:
-- `nix flake lock --update-input hackage` for Hackage
-- `nix flake lock --update-input CHaP` for CHaP
+- `nix flake update hackage` for Hackage
+- `nix flake update CHaP` for CHaP
 
 After updating these, you should also consider updating `haskell.nix` with `nix flake lock --update-input haskell-nix` (although that is not mandatory).
 

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.adoc for how to update index-state
 index-state:
-  , hackage.haskell.org 2024-03-21T00:00:00Z
-  , cardano-haskell-packages 2024-03-21T00:00:00Z
+  , hackage.haskell.org 2024-06-12T10:10:17Z
+  , cardano-haskell-packages 2024-06-12T10:10:17Z
 
 packages: plutus-ledger
           plutus-script-utils

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710945682,
-        "narHash": "sha256-xp1txUjrtCuKHAy0nvz/lu0MlNdNnzvP8l2p9MFB73Y=",
+        "lastModified": 1718200515,
+        "narHash": "sha256-LhZDhH/Ii4X7r+bo7LGC+Q//OiUJ8uRwCJ5ULNpbj00=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "8df2bf06e4525ec39c106cd2593e3c5fd7f2b081",
+        "rev": "b731179078dc9960d68c3d0297d1c26f69e33614",
         "type": "github"
       },
       "original": {
@@ -1031,11 +1031,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1710980597,
-        "narHash": "sha256-3WiA93vz5XSHnW/7AacBCmB2m9EQ9zD1rW9d3Tw7vSE=",
+        "lastModified": 1718152621,
+        "narHash": "sha256-Jx/jLzMEmYOfXhQBs+KTraz+wN6vKsiJoeh1MCeMmcY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "37b89d394bdfd1e6225daff4411f97c979e8d69c",
+        "rev": "5b1c0e6a1e4c4f4b39353c4df8bb8ccf5fc6eee9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# What this PR does

Update CHaP and hackage to a version that contains `cardano-api` 8.46

# Context

This prepares for tackling https://github.com/IntersectMBO/cardano-node-emulator/issues/23 and https://github.com/IntersectMBO/cardano-node-emulator/issues/22