### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Technical writers
+README.*                                                      @Jimbo4350 @newhoggy @carbolymer @smelc @palas @olgahryniuk
+
+# General reviewers for PRs
+#                                                             Jordan     John      Mateusz     Clément Pablo  Kevin         Sam
+*                                                             @Jimbo4350 @newhoggy @carbolymer @smelc  @palas @kevinhammond @disassembler


### PR DESCRIPTION
Adding a `CODEOWNERS` file, taking as example the [CLI one](https://github.com/IntersectMBO/cardano-cli/blob/main/CODEOWNERS).

Note that, contrary to CLI, the teams @intersectmbo/core-tech-devx and @intersectmbo/core-tech-release-1 are not valid owners; since I believe they don't have write access to this repo.