### PR TITLE
Solving TxOutRef issue and a few more errors

### DIFF
--- a/plutus-ledger/src/Ledger/Tx/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/Internal.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Ledger.Tx.Internal (

--- a/plutus-ledger/src/Ledger/Value/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Value/Orphans.hs
@@ -46,9 +46,11 @@ instance FromJSON CurrencySymbol where
       pure $ CurrencySymbol $ PlutusTx.toBuiltin bytes
 
 deriving anyclass instance Hashable CurrencySymbol
+
 deriving newtype instance Serialise CurrencySymbol
 
 deriving anyclass instance Hashable TokenName
+
 deriving newtype instance Serialise TokenName
 
 {- note [Roundtripping token names]
@@ -91,37 +93,49 @@ instance FromJSON TokenName where
         _ -> pure . fromText $ t
 
 deriving anyclass instance ToJSON AssetClass
+
 deriving anyclass instance FromJSON AssetClass
+
 deriving anyclass instance Hashable AssetClass
+
 deriving newtype instance Serialise AssetClass
 
 deriving anyclass instance ToJSON Value
+
 deriving anyclass instance FromJSON Value
+
 deriving anyclass instance Hashable Value
+
 deriving newtype instance Serialise Value
 
 -- Orphan instances for 'PlutusTx.Map' to make this work
 instance (ToJSON v, ToJSON k) => ToJSON (Map.Map k v) where
   toJSON = JSON.toJSON . Map.toList
 
-instance (FromJSON v, FromJSON k) => FromJSON (Map.Map k v) where
-  parseJSON v = Map.fromList <$> JSON.parseJSON v
+instance (FromJSON v, FromJSON k, PlutusTx.Eq k) => FromJSON (Map.Map k v) where
+  parseJSON v = Map.safeFromList <$> JSON.parseJSON v
 
 deriving anyclass instance (Hashable k, Hashable v) => Hashable (Map.Map k v)
+
 deriving anyclass instance (Serialise k, Serialise v) => Serialise (Map.Map k v)
 
 deriving newtype instance Serialise C.Quantity
 
 instance Pretty C.Value where
   pretty = reflow . C.renderValuePretty
+
 instance Serialise C.Value where
   decode = C.valueFromList <$> decode
   encode = encode . C.valueToList
 
 deriving stock instance Generic C.AssetId
+
 deriving anyclass instance FromJSON C.AssetId
+
 deriving anyclass instance ToJSON C.AssetId
+
 deriving anyclass instance Serialise C.AssetId
+
 deriving via (PrettyShow C.AssetId) instance Pretty C.AssetId
 
 instance Serialise C.PolicyId where

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed/Scripts.hs
@@ -20,8 +20,6 @@ where
 
 import Control.Monad.Except (MonadError (throwError))
 import Plutus.Script.Utils.Scripts (MintingPolicy, StakeValidator, Validator, datumHash)
-import Plutus.Script.Utils.V1.Typed.Scripts.Validators (ConnectionError (..))
-import Plutus.Script.Utils.V1.Typed.Scripts.Validators qualified as V1
 import Plutus.Script.Utils.V3.Typed.Scripts.MonetaryPolicies hiding (forwardToValidator)
 import Plutus.Script.Utils.V3.Typed.Scripts.StakeValidators hiding (forwardToValidator)
 import Plutus.Script.Utils.V3.Typed.Scripts.Validators
@@ -76,18 +74,18 @@ typeScriptTxOut
 typeScriptTxOut tv txOutRef txOut datum = do
   case addressCredential (txOutAddress txOut) of
     PubKeyCredential _ ->
-      throwError $ V1.WrongOutType V1.ExpectedScriptGotPubkey
+      throwError $ WrongOutType ExpectedScriptGotPubkey
     ScriptCredential _vh ->
       case txOutDatum txOut of
         OutputDatum d | datumHash datum == datumHash d -> do
-          V1.checkValidatorAddress tv (txOutAddress txOut)
-          dsVal <- V1.checkDatum tv datum
+          checkValidatorAddress tv (txOutAddress txOut)
+          dsVal <- checkDatum tv datum
           pure $ TypedScriptTxOut @out txOut dsVal
         OutputDatumHash dh | datumHash datum == dh -> do
-          V1.checkValidatorAddress tv (txOutAddress txOut)
-          dsVal <- V1.checkDatum tv datum
+          checkValidatorAddress tv (txOutAddress txOut)
+          dsVal <- checkDatum tv datum
           pure $ TypedScriptTxOut @out txOut dsVal
-        _ -> throwError $ V1.NoDatum txOutRef (datumHash datum)
+        _ -> throwError $ NoDatum txOutRef (datumHash datum)
 
 -- | Create a 'TypedScriptTxOut' from an existing 'TxOut' by checking the types of its parts.
 typeScriptTxOutRef

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed/Scripts/Validators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed/Scripts/Validators.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
@@ -12,6 +14,8 @@ module Plutus.Script.Utils.V3.Typed.Scripts.Validators (
   ValidatorTypes (..),
   ValidatorType,
   TypedValidator,
+  WrongOutTypeError (..),
+  ConnectionError (..),
   mkTypedValidator,
   mkTypedValidatorParam,
   validatorHash,
@@ -22,10 +26,17 @@ module Plutus.Script.Utils.V3.Typed.Scripts.Validators (
   vForwardingMintingPolicy,
   forwardingMintingPolicyHash,
   generalise,
+  checkValidatorAddress,
+  checkRedeemer,
+  checkDatum,
 )
 where
 
+import Control.Monad (unless)
+import Control.Monad.Except (MonadError (throwError))
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Kind (Type)
+import GHC.Generics (Generic)
 import Plutus.Script.Utils.Scripts (Language (PlutusV3), Versioned (Versioned), mkValidatorScript)
 import Plutus.Script.Utils.Typed (
   DatumType,
@@ -48,6 +59,7 @@ import PlutusCore.Default (DefaultUni)
 import PlutusCore.Version (plcVersion110)
 import PlutusLedgerApi.V3 qualified as PV3
 import PlutusTx (CompiledCode, Lift, liftCode, unsafeApplyCode)
+import Prettyprinter (Pretty (pretty), viaShow, (<+>))
 
 -- | The type of validators for the given connection type.
 type ValidatorType (a :: Type) = DatumType a -> RedeemerType a -> PV3.ScriptContext -> Bool
@@ -84,3 +96,60 @@ mkTypedValidatorParam
   -> TypedValidator a
 mkTypedValidatorParam vc wrapper param =
   mkTypedValidator (vc `unsafeApplyCode` liftCode plcVersion110 param) wrapper
+
+data WrongOutTypeError
+  = ExpectedScriptGotPubkey
+  | ExpectedPubkeyGotScript
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | An error we can get while trying to type an existing transaction part.
+data ConnectionError
+  = WrongValidatorAddress PV3.Address PV3.Address
+  | WrongOutType WrongOutTypeError
+  | WrongValidatorType String
+  | WrongRedeemerType PV3.BuiltinData
+  | WrongDatumType PV3.BuiltinData
+  | NoDatum PV3.TxOutRef PV3.DatumHash
+  | UnknownRef PV3.TxOutRef
+  deriving stock (Show, Eq, Ord, Generic)
+
+instance Pretty ConnectionError where
+  pretty (WrongValidatorAddress a1 a2) = "Wrong validator address. Expected:" <+> pretty a1 <+> "Actual:" <+> pretty a2
+  pretty (WrongOutType t) = "Wrong out type:" <+> viaShow t
+  pretty (WrongValidatorType t) = "Wrong validator type:" <+> pretty t
+  pretty (WrongRedeemerType d) = "Wrong redeemer type" <+> pretty (PV3.builtinDataToData d)
+  pretty (WrongDatumType d) = "Wrong datum type" <+> pretty (PV3.builtinDataToData d)
+  pretty (NoDatum t d) = "No datum with hash " <+> pretty d <+> "for tx output" <+> pretty t
+  pretty (UnknownRef d) = "Unknown reference" <+> pretty d
+
+-- | Checks that the given validator hash is consistent with the actual validator.
+checkValidatorAddress
+  :: forall a m. (MonadError ConnectionError m) => TypedValidator a -> PV3.Address -> m ()
+checkValidatorAddress ct actualAddr = do
+  let expectedAddr = validatorAddress ct
+  unless (expectedAddr == actualAddr) $ throwError $ WrongValidatorAddress expectedAddr actualAddr
+
+-- | Checks that the given redeemer script has the right type.
+checkRedeemer
+  :: forall inn m
+   . (PV3.FromData (RedeemerType inn), MonadError ConnectionError m)
+  => TypedValidator inn
+  -> PV3.Redeemer
+  -> m (RedeemerType inn)
+checkRedeemer _ (PV3.Redeemer d) =
+  case PV3.fromBuiltinData d of
+    Just v -> pure v
+    Nothing -> throwError $ WrongRedeemerType d
+
+-- | Checks that the given datum has the right type.
+checkDatum
+  :: forall a m
+   . (PV3.FromData (DatumType a), MonadError ConnectionError m)
+  => TypedValidator a
+  -> PV3.Datum
+  -> m (DatumType a)
+checkDatum _ (PV3.Datum d) =
+  case PV3.fromBuiltinData d of
+    Just v -> pure v
+    Nothing -> throwError $ WrongDatumType d


### PR DESCRIPTION
This is NOT a full fix for compilation error of upgrading cardano-api. However, this is a start. It does fix:
- wrong version of `TxOutRef`
- one unused language pragma
- outdated usage of `PlutusTx.Map.FromList`