### PR TITLE
Fixing wrong exported `TxOutRef`

### DIFF
--- a/cardano-node-emulator/cardano-node-emulator.cabal
+++ b/cardano-node-emulator/cardano-node-emulator.cabal
@@ -26,7 +26,8 @@ common lang
     -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
     -Wredundant-constraints -Wmissing-import-lists -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
-    -fplugin-opt PlutusTx.Plugin:target-version=1.1.0
+    -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 -fplugin-opt
+    PlutusTx.Plugin:defer-errors
 
   -- The limitation of plutus-tx-plugin
   if (impl(ghc <9.6) || impl(ghc >=9.7))

--- a/cardano-node-socket-emulator/cardano-node-socket-emulator.cabal
+++ b/cardano-node-socket-emulator/cardano-node-socket-emulator.cabal
@@ -23,7 +23,8 @@ common lang
     -Wall -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
     -Wredundant-constraints -fplugin-opt
-    PlutusTx.Plugin:target-version=1.1.0
+    PlutusTx.Plugin:target-version=1.1.0 -fplugin-opt
+    PlutusTx.Plugin:defer-errors
 
   -- The limitation of plutus-tx-plugin
   if (impl(ghc <9.6) || impl(ghc >=9.7))

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -41,18 +41,12 @@ common lang
     -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wredundant-constraints -Widentities -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
-    -fplugin-opt PlutusTx.Plugin:target-version=1.1.0
+    -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 -fplugin-opt
+    PlutusTx.Plugin:defer-errors
 
   -- The limitation of plutus-tx-plugin
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
-
-flag defer-plugin-errors
-  description:
-    Defer errors from the plugin, useful for things like Haddock that can't handle it.
-
-  default:     False
-  manual:      True
 
 library
   import:           lang
@@ -157,9 +151,6 @@ library
     , vector
 
   ghc-options:      -fprint-potential-instances
-
-  if flag(defer-plugin-errors)
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite plutus-ledger-test
   import:             lang

--- a/plutus-ledger/src/Ledger.hs
+++ b/plutus-ledger/src/Ledger.hs
@@ -17,7 +17,7 @@ import Ledger.Slot as Export
 import Ledger.Tx as Export
 import Ledger.Value.CardanoAPI as Export hiding (singleton)
 import PlutusLedgerApi.V1 (Credential, DCert)
-import PlutusLedgerApi.V1.Contexts as Export hiding (TxId (..), TxOut (..))
+import PlutusLedgerApi.V1.Contexts as Export hiding (TxId (..), TxOut (..), TxOutRef (..))
 import PlutusLedgerApi.V1.Credential (StakingCredential)
 import PlutusLedgerApi.V1.Interval as Export
 import PlutusLedgerApi.V1.Time as Export

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -128,7 +128,7 @@ import Ledger.Tx.CardanoAPI (
 import Ledger.Tx.CardanoAPI qualified as CardanoAPI
 
 import Plutus.Script.Utils.Scripts (Script, Validator, ValidatorHash (..), scriptHash)
-import PlutusLedgerApi.V1 qualified as V1
+import PlutusLedgerApi.V1 qualified as V1 hiding (TxOutRef (..))
 import PlutusLedgerApi.V2 qualified as V2
 import PlutusLedgerApi.V2.Tx qualified as V2.Tx hiding (TxId (..))
 
@@ -142,6 +142,7 @@ import Ledger.Tx.Internal as Export
 import PlutusLedgerApi.V1.Tx as Export hiding (
   TxId (..),
   TxOut (..),
+  TxOutRef (..),
   outAddress,
   outValue,
   txOutDatum,

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -51,10 +51,11 @@ import Ledger.Tx.CardanoAPI.Internal
 import Ledger.Tx.Internal qualified as P
 import Plutus.Script.Utils.Scripts qualified as PV1
 import PlutusLedgerApi.V1 qualified as PV1
+import PlutusLedgerApi.V3 qualified as PV3
 
 toCardanoMintWitness
   :: PV1.Redeemer
-  -> Maybe (P.Versioned PV1.TxOutRef)
+  -> Maybe (P.Versioned PV3.TxOutRef)
   -> Maybe (P.Versioned PV1.MintingPolicy)
   -> Either ToCardanoError (C.ScriptWitness C.WitCtxMint C.ConwayEra)
 toCardanoMintWitness _ Nothing Nothing = Left MissingMintingPolicy
@@ -67,7 +68,7 @@ toCardanoScriptWitness
   :: (PV1.ToData a)
   => C.ScriptDatum witctx
   -> a
-  -> Either (P.Versioned PV1.Script) (P.Versioned PV1.TxOutRef)
+  -> Either (P.Versioned PV1.Script) (P.Versioned PV3.TxOutRef)
   -> Either ToCardanoError (C.ScriptWitness witctx C.ConwayEra)
 toCardanoScriptWitness datum redeemer scriptOrRef =
   ( case scriptOrRef of
@@ -89,7 +90,7 @@ type WitnessHeader witctx =
   C.ScriptDatum witctx -> C.ScriptRedeemer -> C.ExecutionUnits -> C.ScriptWitness witctx C.ConwayEra
 
 toCardanoTxInReferenceWitnessHeader
-  :: P.Versioned PV1.TxOutRef -> Either ToCardanoError (WitnessHeader witctx)
+  :: P.Versioned PV3.TxOutRef -> Either ToCardanoError (WitnessHeader witctx)
 toCardanoTxInReferenceWitnessHeader (P.Versioned ref lang) = do
   txIn <- toCardanoTxIn ref
   pure $ case lang of
@@ -149,10 +150,10 @@ toPlutusIndex (C.Ledger.UTxO utxo) =
 fromPlutusIndex :: P.UtxoIndex -> C.Ledger.UTxO (Conway.ConwayEra StandardCrypto)
 fromPlutusIndex = C.toLedgerUTxO C.ShelleyBasedEraConway
 
-fromPlutusTxOutRef :: P.TxOutRef -> Either ToCardanoError (C.Ledger.TxIn StandardCrypto)
-fromPlutusTxOutRef (P.TxOutRef txId i) = C.Ledger.TxIn <$> fromPlutusTxId txId <*> pure (mkTxIxPartial i)
+fromPlutusTxOutRef :: PV3.TxOutRef -> Either ToCardanoError (C.Ledger.TxIn StandardCrypto)
+fromPlutusTxOutRef (PV3.TxOutRef txId i) = C.Ledger.TxIn <$> fromPlutusTxId txId <*> pure (mkTxIxPartial i)
 
-fromPlutusTxId :: PV1.TxId -> Either ToCardanoError (C.Ledger.TxId StandardCrypto)
+fromPlutusTxId :: PV3.TxId -> Either ToCardanoError (C.Ledger.TxId StandardCrypto)
 fromPlutusTxId = fmap C.toShelleyTxId . toCardanoTxId
 
 fromPlutusTxOut :: P.TxOut -> Ledger.TxOut (Conway.ConwayEra StandardCrypto)

--- a/plutus-ledger/src/Ledger/Tx/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/Internal.hs
@@ -40,7 +40,7 @@ import Cardano.Api (TxBodyContent (txValidityLowerBound))
 import Plutus.Script.Utils.Scripts
 import PlutusLedgerApi.V1 (Credential, DCert, dataToBuiltinData)
 import PlutusLedgerApi.V1.Scripts
-import PlutusLedgerApi.V1.Tx hiding (TxOut (..))
+import PlutusLedgerApi.V3.Tx (TxOutRef (..))
 import PlutusTx (FromData (..), fromData)
 import PlutusTx.Prelude qualified as PlutusTx
 import Prettyprinter (Pretty (..), viaShow)

--- a/plutus-script-utils/plutus-script-utils.cabal
+++ b/plutus-script-utils/plutus-script-utils.cabal
@@ -44,18 +44,12 @@ common lang
     -Wredundant-constraints -Widentities -Wmissing-import-lists
     -fobject-code -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas -fplugin-opt
-    PlutusTx.Plugin:target-version=1.1.0
+    PlutusTx.Plugin:target-version=1.1.0 -fplugin-opt
+    PlutusTx.Plugin:defer-errors
 
   -- The limitation of plutus-tx-plugin
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
-
-flag defer-plugin-errors
-  description:
-    Defer errors from the plugin, useful for things like Haddock that can't handle it.
-
-  default:     False
-  manual:      True
 
 library
   import:           lang
@@ -125,9 +119,6 @@ library
 
   -- TODO This needs to be changed to 1.35 once cardano-node creates the tag
   ghc-options:      -fprint-potential-instances
-
-  if flag(defer-plugin-errors)
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite plutus-ledger-test
   import:             lang


### PR DESCRIPTION
Following the update of cardano-api and associated libraries. The wrong `TxOutRef` was exported because a new version of `TxOutRef` was released (due to a different Builtindata representation of the `TxId`).

This PR bumps the version of `TxOutRef` exported and used in `cardano-node-emulator.`

In the meantime, as I was having issues fixing this properly without HLS, I enabled the `defer-errors` flag by default which usually makes HLS works much better. This is in fact the case here as well, where all files are now successfully handled.