### PR TITLE
Update capi, flake.lock and protocol version

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2025-11-05T09:40:54Z
-  , cardano-haskell-packages 2025-11-18T18:44:49Z
+  , cardano-haskell-packages 2025-11-20T19:29:50Z
 
 packages: plutus-ledger
           plutus-script-utils
@@ -22,7 +22,7 @@ packages: plutus-ledger
           freer-extras
 
 constraints:
-  cardano-api == 10.20.0.0
+  , cardano-api == 10.18.0.0
           
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2025-04-16T16:04:13Z
-  , cardano-haskell-packages 2025-05-16T15:25:35Z
+  , cardano-haskell-packages 2025-06-11T08:32:56Z
       
 packages: plutus-ledger
           plutus-script-utils
@@ -22,7 +22,7 @@ packages: plutus-ledger
           freer-extras
 
 constraints:
-  cardano-api == 10.16.1.0
+  cardano-api == 10.17.0.0
           
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-04-16T16:04:13Z
-  , cardano-haskell-packages 2025-06-11T08:32:56Z
+  , hackage.haskell.org 2025-06-22T20:18:27Z
+  , cardano-haskell-packages 2025-07-14T17:31:29Z
       
 packages: plutus-ledger
           plutus-script-utils
@@ -22,7 +22,7 @@ packages: plutus-ledger
           freer-extras
 
 constraints:
-  cardano-api == 10.17.0.0
+  cardano-api == 10.17.2.0
           
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -12,9 +12,9 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-04-16T16:04:13Z
-  , cardano-haskell-packages 2025-06-11T08:32:56Z
-      
+  , hackage.haskell.org 2025-11-05T09:40:54Z
+  , cardano-haskell-packages 2025-11-18T18:44:49Z
+
 packages: plutus-ledger
           plutus-script-utils
           cardano-node-emulator
@@ -22,7 +22,7 @@ packages: plutus-ledger
           freer-extras
 
 constraints:
-  cardano-api == 10.17.0.0
+  cardano-api == 10.20.0.0
           
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Generators.hs
@@ -63,7 +63,6 @@ module Cardano.Node.Emulator.Generators
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Crypto.Wallet qualified as Crypto
 import Cardano.Ledger.Api.PParams (ppMaxCollateralInputsL)
 import Cardano.Ledger.Shelley.API (Coin (Coin))
@@ -91,7 +90,6 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.String (fromString)
 import GHC.Exts (fromList)
 import GHC.Stack (HasCallStack)
 import Hedgehog (Gen, MonadGen, MonadTest, Range)
@@ -407,13 +405,7 @@ genSizedByteString s =
 
 -- Copied from Gen.Cardano.Api.Typed, because it's not exported.
 genPolicyId :: Gen C.PolicyId
-genPolicyId =
-  Gen.frequency
-    -- mostly from a small number of choices, so we get plenty of repetition
-    [ (9, Gen.element [fromString (x : replicate 55 '0') | x <- ['a' .. 'c']]),
-      -- and some from the full range of the type
-      (1, C.PolicyId <$> Gen.genScriptHash)
-    ]
+genPolicyId = Gen.frequency [(1, C.PolicyId <$> Gen.genScriptHash)]
 
 -- Copied from Gen.Cardano.Api.Typed, because it's not exported.
 genAssetId :: Gen C.AssetId

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Params.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Params.hs
@@ -41,7 +41,6 @@ module Cardano.Node.Emulator.Internal.Node.Params
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Ledger.Alonzo.Genesis qualified as C
 import Cardano.Ledger.Alonzo.PParams qualified as C
 import Cardano.Ledger.Api.PParams qualified as C
@@ -154,7 +153,7 @@ increaseTransactionLimits' size steps mem =
       ExUnits (steps * executionSteps) (mem * executionMemory)
 
 emulatorProtocolMajorVersion :: Version
-emulatorProtocolMajorVersion = natVersion @9
+emulatorProtocolMajorVersion = natVersion @10
 
 defaultConfig :: TransitionConfig
 defaultConfig =

--- a/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Validation.hs
+++ b/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Validation.hs
@@ -24,8 +24,7 @@ module Cardano.Node.Emulator.Internal.Node.Validation
   )
 where
 
-import Cardano.Api.Internal.Error qualified as C.Api
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Cardano.Ledger.Alonzo.Plutus.Evaluate qualified as Alonzo
 import Cardano.Ledger.Alonzo.Rules qualified as Alonzo
 import Cardano.Ledger.Alonzo.Tx qualified as Alonzo

--- a/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator.hs
+++ b/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TupleSections #-}
 
 module Cardano.Node.Socket.Emulator
   ( main,
@@ -9,8 +10,7 @@ module Cardano.Node.Socket.Emulator
   )
 where
 
-import Cardano.Api (NetworkId, NetworkMagic (NetworkMagic), toNetworkMagic)
-import Cardano.Api.Internal.Genesis (ShelleyGenesis (sgNetworkMagic, sgSlotLength))
+import Cardano.Api (NetworkId, NetworkMagic (NetworkMagic), ShelleyGenesis (sgNetworkMagic, sgSlotLength), toNetworkMagic)
 import Cardano.BM.Trace (Trace, stdoutTrace)
 import Cardano.Node.Emulator.Internal.Node (SlotConfig (SlotConfig, scSlotLength, scSlotZeroTime))
 import Cardano.Node.Emulator.Internal.Node.Params (keptBlocks, pSlotConfig)
@@ -53,7 +53,7 @@ core
       let getAddress n = knownAddresses !! (fromIntegral n - 1)
           dist =
             Map.fromList $
-              zip (getAddress <$> nscInitialTxWallets) (repeat (CardanoAPI.adaValueOf 1_000_000_000))
+              map (,CardanoAPI.adaValueOf 1_000_000_000) (getAddress <$> nscInitialTxWallets)
       params <- liftIO $ Params.fromNodeServerConfig updateShelley nodeServerConfig
       initialState <- initialChainState params dist
       let appState = AppState initialState mempty params

--- a/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Params.hs
+++ b/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Params.hs
@@ -2,7 +2,7 @@
 
 module Cardano.Node.Socket.Emulator.Params where
 
-import Cardano.Api.Internal.Genesis (ShelleyGenesis)
+import Cardano.Api (ShelleyGenesis)
 import Cardano.Node.Emulator.Internal.Node.Params
 import Cardano.Node.Socket.Emulator.Types
 import Data.Aeson (FromJSON, eitherDecode)

--- a/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Query.hs
+++ b/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Query.hs
@@ -4,7 +4,6 @@
 module Cardano.Node.Socket.Emulator.Query (handleQuery) where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Ledger.Api.Transition qualified as C
 import Cardano.Ledger.BaseTypes (epochInfo)
 import Cardano.Node.Emulator.API qualified as E

--- a/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Server.hs
+++ b/cardano-node-socket-emulator/src/Cardano/Node/Socket/Emulator/Server.hs
@@ -12,7 +12,6 @@
 module Cardano.Node.Socket.Emulator.Server (ServerHandler, runServerNode, processBlock, modifySlot, addTx, processChainEffects) where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.Node.Emulator.API qualified as E
 import Cardano.Node.Emulator.Internal.API (EmulatorMsg, EmulatorT)
@@ -206,8 +205,8 @@ pruneChain k original = do
         then {- When the counter reaches zero, there are K blocks in the
                 original channel and we start to remove the oldest stored
                 block by reading it. -}
-        do
-          liftIO $ atomically (readTChan original) >> go 0 localChannel
+          do
+            liftIO $ atomically (readTChan original) >> go 0 localChannel
         else do
           go (k' - 1) localChannel
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750074913,
-        "narHash": "sha256-yJvO1VmLQ0qJYOpdqRaLop+Kr1A+anOlp6cXxe4syFA=",
+        "lastModified": 1764420875,
+        "narHash": "sha256-B4cYfjwjSSeGNrNiJxtgh2Rg3HVoonY9k7jl5UsNwnk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef9d1ea73f33a1b0366aaf6861a6618906a91a57",
+        "rev": "8d831d8cd9b8a1ce1970cfdfc421382f3b9d48d3",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
-        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764420875,
-        "narHash": "sha256-B4cYfjwjSSeGNrNiJxtgh2Rg3HVoonY9k7jl5UsNwnk=",
+        "lastModified": 1764428090,
+        "narHash": "sha256-HdQjtllzCdke+Wn30N8ahJp0OObKkqyMNAp6e9D8TGs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d831d8cd9b8a1ce1970cfdfc421382f3b9d48d3",
+        "rev": "a8b1b9d111a59aa84da310185d03e6adc763f3a1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744203096,
-        "narHash": "sha256-349IzhCLF2NbVVYoHvYh4Hci/WZWHiBPgZld4B//EbE=",
+        "lastModified": 1750074913,
+        "narHash": "sha256-yJvO1VmLQ0qJYOpdqRaLop+Kr1A+anOlp6cXxe4syFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a40000092d2524511259caccd884a3ce96ec478",
+        "rev": "ef9d1ea73f33a1b0366aaf6861a6618906a91a57",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1749636823,
+        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750074913,
-        "narHash": "sha256-yJvO1VmLQ0qJYOpdqRaLop+Kr1A+anOlp6cXxe4syFA=",
+        "lastModified": 1753189213,
+        "narHash": "sha256-DFKb6g/SNgHP9rlfY8MlD367IPsRnWG9/uIQrqcr68k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef9d1ea73f33a1b0366aaf6861a6618906a91a57",
+        "rev": "60527488b4eb95913c5f1874a301f2b323ab8916",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
-        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753189213,
-        "narHash": "sha256-DFKb6g/SNgHP9rlfY8MlD367IPsRnWG9/uIQrqcr68k=",
+        "lastModified": 1753197470,
+        "narHash": "sha256-/wXGVVDkAuNyI+GQBrcAap4mX6pIDW13tIfFClSOSNI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60527488b4eb95913c5f1874a301f2b323ab8916",
+        "rev": "cca17a98bf56cb54bd340c9447d45df619a274a5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
           LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
             pkgs.xz
             pkgs.zlib
+            pkgs.lmdb
             pkgs.openssl_3_5
             pkgs.postgresql # For cardano-node-emulator
             pkgs.openldap # For freer-extras‽

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
           LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
             pkgs.xz
             pkgs.zlib
+            pkgs.lmdb
             pkgs.openssl_3_6
             pkgs.postgresql # For cardano-node-emulator
             pkgs.openldap # For freer-extras‽

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             pkgs.lmdb
             hpkgs.ghc
             hpkgs.cabal-install
+            hpkgs.cabal-plan
           ];
 
           ## Folders in which to find ".so" files

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
             pkgs.xz
             pkgs.zlib
-            pkgs.openssl_3_4
+            pkgs.openssl_3_5
             pkgs.postgresql # For cardano-node-emulator
             pkgs.openldap # For freer-extras‽
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
             pkgs.xz
             pkgs.zlib
-            pkgs.openssl_3_4
+            pkgs.openssl_3_6
             pkgs.postgresql # For cardano-node-emulator
             pkgs.openldap # For freer-extras‽
           ];

--- a/plutus-ledger/src/Ledger/Address.hs
+++ b/plutus-ledger/src/Ledger/Address.hs
@@ -35,7 +35,6 @@ module Ledger.Address
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Chain.Common (addrToBase58)
 import Cardano.Crypto.Wallet qualified as Crypto
 import Codec.Serialise (Serialise)

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -50,7 +50,6 @@ module Ledger.Index
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C.Api
 import Cardano.Ledger.Coin (Coin (Coin))
 import Cardano.Ledger.Conway qualified as Conway
 import Cardano.Ledger.Core (PParams, getMinCoinTxOut)
@@ -208,7 +207,7 @@ maxFee = PV1.Lovelace 1_000_000
 -- | cardano-ledger validation rules require the presence of inputs and
 -- we have to provide a stub TxIn for the genesis transaction.
 genesisTxIn :: C.TxIn
-genesisTxIn = C.TxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53" (C.TxIx 40_214)
+genesisTxIn = C.TxIn (C.TxId "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53") (C.TxIx 40_214)
 
 createGenesisTransaction :: Map.Map CardanoAddress Value -> CardanoTx
 createGenesisTransaction vals =
@@ -217,7 +216,7 @@ createGenesisTransaction vals =
           { C.txIns = [(genesisTxIn, C.BuildTxWith (C.KeyWitness C.KeyWitnessForSpending))],
             C.txOuts =
               Map.toList vals <&> \(changeAddr, v) ->
-                C.TxOut changeAddr (toCardanoTxOutValue v) C.TxOutDatumNone C.Api.ReferenceScriptNone
+                C.TxOut changeAddr (toCardanoTxOutValue v) C.TxOutDatumNone C.ReferenceScriptNone
           }
       txBody =
         either (error . ("createGenesisTransaction: Can't create TxBody: " <>) . show) id $

--- a/plutus-ledger/src/Ledger/Index/Internal.hs
+++ b/plutus-ledger/src/Ledger/Index/Internal.hs
@@ -16,7 +16,6 @@
 module Ledger.Index.Internal where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Binary qualified as CBOR
 import Cardano.Ledger.Alonzo.Scripts (AsIx, ExUnits, PlutusPurpose)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (AlonzoTx), IsValid (IsValid))

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI.hs
@@ -33,7 +33,6 @@ module Ledger.Tx.CardanoAPI
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.BaseTypes (mkTxIxPartial)
 import Cardano.Ledger.Conway qualified as Conway

--- a/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/CardanoAPI/Internal.hs
@@ -92,8 +92,6 @@ module Ledger.Tx.CardanoAPI.Internal
 where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Internal.Error qualified as C
-import Cardano.Api.Shelley qualified as C
 import Cardano.BM.Data.Tracer (ToObject)
 import Cardano.Chain.Common (addrToBase58)
 import Cardano.Ledger.Alonzo.Scripts qualified as Alonzo
@@ -550,7 +548,7 @@ toCardanoPolicyId (P.MintingPolicyHash bs) =
       (deserialiseFromRawBytes C.AsPolicyId (PlutusTx.fromBuiltin bs))
 
 fromCardanoAssetName :: C.AssetName -> Value.TokenName
-fromCardanoAssetName (C.AssetName bs) = Value.TokenName $ PlutusTx.toBuiltin bs
+fromCardanoAssetName (C.UnsafeAssetName bs) = Value.TokenName $ PlutusTx.toBuiltin bs
 
 toCardanoAssetName :: Value.TokenName -> Either ToCardanoError C.AssetName
 toCardanoAssetName (Value.TokenName bs) =

--- a/plutus-ledger/src/Ledger/Tx/Internal.hs
+++ b/plutus-ledger/src/Ledger/Tx/Internal.hs
@@ -20,8 +20,6 @@ where
 
 import Cardano.Api (TxBodyContent (txValidityLowerBound))
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
-import Cardano.Binary qualified as C
 import Cardano.Ledger.Alonzo.Genesis ()
 import Codec.Serialise (Serialise, decode, encode)
 import Control.Lens qualified as L

--- a/plutus-ledger/src/Ledger/Tx/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Tx/Orphans.hs
@@ -11,7 +11,6 @@
 module Ledger.Tx.Orphans where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import Codec.Serialise.Class (Serialise (..))
 import Data.Aeson
   ( FromJSON (parseJSON),
@@ -73,9 +72,6 @@ instance Pretty (C.TxOutDatum C.CtxUTxO era) where
   pretty C.TxOutDatumNone = "no datum"
   pretty (C.TxOutDatumInline _ dv) = "with inline datum" <+> viaShow dv
   pretty (C.TxOutDatumHash _ dh) = "with datum hash" <+> fromString (init . tail $ show dh)
-
-instance Pretty C.TxId where
-  pretty (C.TxId h) = fromString (init $ tail $ show h)
 
 instance Serialise C.TxId where
   encode = encode . C.serialiseToRawBytes

--- a/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
+++ b/plutus-ledger/test/Ledger/Tx/CardanoAPISpec.hs
@@ -14,11 +14,8 @@ import Cardano.Api
     StakeAddressReference (NoStakeAddress, StakeAddressByValue),
     StakeCredential,
     makeShelleyAddress,
-    shelleyAddressInEra,
   )
 import Cardano.Api qualified as C
-import Cardano.Api.Shelley (StakeCredential (StakeCredentialByKey), shelleyBasedEra)
-import Cardano.Api.Shelley qualified as C
 import GHC.Exts (fromList)
 import Hedgehog (Gen, Property, forAll, property, tripping, (===))
 import Hedgehog qualified
@@ -93,7 +90,7 @@ addressRoundTripSpec :: Property
 addressRoundTripSpec = property $ do
   networkId <- forAll genNetworkId
   shelleyAddr <-
-    shelleyAddressInEra shelleyBasedEra
+    C.shelleyAddressInEra C.shelleyBasedEra
       <$> forAll
         ( makeShelleyAddress networkId
             <$> genPaymentCredential
@@ -121,7 +118,7 @@ genStakeAddressReference =
 genStakeCredential :: Gen StakeCredential
 genStakeCredential = do
   vKey <- Gen.genVerificationKey AsStakeKey
-  return . StakeCredentialByKey $ verificationKeyHash vKey
+  return . C.StakeCredentialByKey $ verificationKeyHash vKey
 
 -- Copied from Gen.Cardano.Api.Typed, because it's not exported.
 genNetworkId :: Gen NetworkId

--- a/plutus-script-utils/plutus-script-utils.cabal
+++ b/plutus-script-utils/plutus-script-utils.cabal
@@ -120,7 +120,6 @@ library
     , bytestring
     , data-default
     , mtl
-    , optics-core
     , prettyprinter
     , serialise
     , tagged

--- a/plutus-script-utils/src/Plutus/Script/Utils/Address.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Address.hs
@@ -7,7 +7,7 @@ module Plutus.Script.Utils.Address
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import PlutusLedgerApi.V1 qualified as Api
 
 class ToCredential a where

--- a/plutus-script-utils/src/Plutus/Script/Utils/Data.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Data.hs
@@ -8,7 +8,7 @@ module Plutus.Script.Utils.Data
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import PlutusLedgerApi.V1 qualified as PV1
 import PlutusLedgerApi.V2 qualified as PV2
 import PlutusTx.Builtins qualified as Builtins

--- a/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
@@ -208,6 +208,9 @@ instance ToValidatorHash PV1.ScriptHash where
 instance ToValidatorHash (Versioned Validator) where
   toValidatorHash = toValidatorHash . toScriptHash . fmap toScript
 
+instance ToValidatorHash (Versioned Script) where
+  toValidatorHash = toValidatorHash . toScriptHash
+
 instance ToScriptHash ValidatorHash where
   toScriptHash = coerce
 
@@ -268,6 +271,9 @@ instance ToMintingPolicyHash PV1.ScriptHash where
 
 instance ToMintingPolicyHash (Versioned MintingPolicy) where
   toMintingPolicyHash = toMintingPolicyHash . toScriptHash . fmap toScript
+
+instance ToMintingPolicyHash (Versioned Script) where
+  toMintingPolicyHash = toMintingPolicyHash . toScriptHash
 
 instance ToMintingPolicyHash PV1.CurrencySymbol where
   toMintingPolicyHash = coerce
@@ -338,6 +344,9 @@ instance ToStakeValidatorHash PV1.ScriptHash where
 
 instance ToStakeValidatorHash (Versioned StakeValidator) where
   toStakeValidatorHash = toStakeValidatorHash . toScriptHash . fmap toScript
+
+instance ToStakeValidatorHash (Versioned Script) where
+  toStakeValidatorHash = toStakeValidatorHash . toScriptHash
 
 instance ToScriptHash StakeValidatorHash where
   toScriptHash = coerce

--- a/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/Scripts.hs
@@ -25,7 +25,7 @@ module Plutus.Script.Utils.Scripts
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Cardano.Ledger.Plutus.Language (Language (PlutusV1, PlutusV2, PlutusV3))
 import Codec.Serialise (Serialise)
 import Data.Aeson (FromJSON, ToJSON)

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1.hs
@@ -7,7 +7,7 @@ module Plutus.Script.Utils.V1
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Plutus.Script.Utils.Address as X
 import Plutus.Script.Utils.Data as X
 import Plutus.Script.Utils.Scripts as X

--- a/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V1/Typed.hs
@@ -33,7 +33,7 @@ module Plutus.Script.Utils.V1.Typed
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Control.Monad (unless)
 import Control.Monad.Except (MonadError (throwError))
 import Data.Aeson (FromJSON, ToJSON)
@@ -274,7 +274,8 @@ checkDatum _ (Datum d) =
 type IsDataDatum a = (FromData (DatumType a), ToData (DatumType a))
 
 -- | A 'TxOut' tagged by a phantom type: the connection type of the output.
-data TypedScriptTxOut a = (IsDataDatum a) =>
+data TypedScriptTxOut a
+  = (IsDataDatum a) =>
   TypedScriptTxOut
   { tyTxOutTxOut :: TxOut,
     tyTxOutData :: DatumType a

--- a/plutus-script-utils/src/Plutus/Script/Utils/V2.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V2.hs
@@ -7,7 +7,7 @@ module Plutus.Script.Utils.V2
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Plutus.Script.Utils.Address as X
 import Plutus.Script.Utils.Data as X
 import Plutus.Script.Utils.Scripts as X

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3.hs
@@ -7,7 +7,7 @@ module Plutus.Script.Utils.V3
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Plutus.Script.Utils.Address as X
 import Plutus.Script.Utils.Data as X
 import Plutus.Script.Utils.Scripts as X

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Generators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Generators.hs
@@ -317,6 +317,12 @@ trueSpendingMPScript = MultiPurposeScript $ toScript $$(compile [||script||])
         $ falseTypedMultiPurposeScript
         `withSpendingPurpose` trueSpendingPurpose @() @() @()
 
+-- | The multi-purpose script that returns @True@ in all purposes
+trueMPScript :: MultiPurposeScript a
+trueMPScript = MultiPurposeScript $ toScript $$(compile [||script||])
+  where
+    script = mkMultiPurposeScript trueTypedMultiPurposeScript
+
 falseMPScript :: MultiPurposeScript a
 falseMPScript = MultiPurposeScript $ toScript $$(compile [||script||])
   where

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Generators.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Generators.hs
@@ -28,6 +28,7 @@ module Plutus.Script.Utils.V3.Generators
     trueMintingMPScript,
     trueSpendingMPScript,
     falseMPScript,
+    trueMPScript,
     multiPurposeScriptValue,
   )
 where

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed.hs
@@ -41,6 +41,7 @@ import Control.Monad.Except
     throwError,
   )
 import Data.Coerce (coerce)
+import Data.Kind (Type)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Plutus.Script.Utils.Address
@@ -296,7 +297,7 @@ data
 -- * Compiled multi-purpose scripts
 
 -- | A 'MultiPurposeScript' is a 'Script' with a phantom connection type
-newtype MultiPurposeScript a = MultiPurposeScript {getMultiPurposeScript :: Script}
+newtype MultiPurposeScript (a :: Type) = MultiPurposeScript {getMultiPurposeScript :: Script}
   deriving stock (Generic)
   deriving newtype (Eq, Ord, Serialise)
   deriving (PP.Pretty) via (PP.PrettyShow (MultiPurposeScript a))

--- a/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed.hs
+++ b/plutus-script-utils/src/Plutus/Script/Utils/V3/Typed.hs
@@ -33,7 +33,7 @@ module Plutus.Script.Utils.V3.Typed
   )
 where
 
-import Cardano.Api.Shelley qualified as C.Api
+import Cardano.Api qualified as C.Api
 import Codec.Serialise (Serialise)
 import Control.Monad (unless)
 import Control.Monad.Except
@@ -269,20 +269,21 @@ data
     spendingRed
     spendingTxInfo
     votingRed
-    votingTxInfo = ( FromData certifyingRed,
-                     FromData certifyingTxInfo,
-                     FromData mintingRed,
-                     FromData mintingTxInfo,
-                     FromData proposingRed,
-                     FromData proposingTxInfo,
-                     FromData rewardingRed,
-                     FromData rewardingTxInfo,
-                     FromData spendingDat,
-                     FromData spendingRed,
-                     FromData spendingTxInfo,
-                     FromData votingRed,
-                     FromData votingTxInfo
-                   ) =>
+    votingTxInfo
+  = ( FromData certifyingRed,
+      FromData certifyingTxInfo,
+      FromData mintingRed,
+      FromData mintingTxInfo,
+      FromData proposingRed,
+      FromData proposingTxInfo,
+      FromData rewardingRed,
+      FromData rewardingTxInfo,
+      FromData spendingDat,
+      FromData spendingRed,
+      FromData spendingTxInfo,
+      FromData votingRed,
+      FromData votingTxInfo
+    ) =>
   TypedMultiPurposeScript
   { certifyingPurpose :: Maybe (CertifyingPurposeType' certifyingRed certifyingTxInfo),
     mintingPurpose :: Maybe (MintingPurposeType' mintingRed mintingTxInfo),
@@ -463,7 +464,8 @@ checkDatum _ (Datum d) =
 type IsDataDatum a = (FromData (SpendingDatumType a), ToData (SpendingDatumType a))
 
 -- | A 'TxOut' tagged by a phantom type: and the connection type of the output.
-data TypedScriptTxOut a = (IsDataDatum a) =>
+data TypedScriptTxOut a
+  = (IsDataDatum a) =>
   TypedScriptTxOut
   { tyTxOutTxOut :: TxOut,
     tyTxOutData :: SpendingDatumType a


### PR DESCRIPTION
This is a minor PR that:
* updates the Emulator protocol version (from 9 to 10)
* updates the flake.lock dependencies
* updates the cardano-api version and associated dependencies
* removes the dependency to optics-core and associated optics (that were not INLINEABLE and should not have been introduced)